### PR TITLE
Making it work with Centos/RHEL 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ NAME_ykksm-gen-keys = 'Tool to generate keys on the YKKSM-KEYPROV format.'
 NAME_ykksm-import = 'Tool to import key data on the YKKSM-KEYPROV format.'
 
 %.1: %
-	help2man -N --name=$(NAME_$*) --version-string=1 ./$* > $@
+	help2man -N --name=$(NAME_$*)  --help ./$* > $@
 
 man: $(MANS)
 


### PR DESCRIPTION
The --version-string string is supported in version 1.37 of help2man. Centos/RHEL 6 ships with 1.36.4.
