### PR TITLE
Standardise logging in YK-KSM to be like YK-VAL and don't log by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ VERSION = 1.14
 PACKAGE = yubikey-ksm
 CODE = .htaccess Makefile NEWS README ykksm-config.php ykksm-db.sql	\
 	ykksm-decrypt.php ykksm-export ykksm-gen-keys	\
-	ykksm-import ykksm-utils.php ykksm-checksum
+	ykksm-import ykksm-utils.php ykksm-log.php ykksm-checksum
 DOCS = doc/DecryptionProtocol.wiki doc/DesignGoals.wiki		\
 	doc/GenerateKeys.wiki doc/GenerateKSMKey.wiki		\
 	doc/ImportKeysToKSM.wiki doc/Installation.wiki		\
@@ -56,6 +56,7 @@ wwwgroup = www-data
 install: $(MANS)
 	install -D --mode 640 .htaccess $(DESTDIR)$(phpprefix)/.htaccess
 	install -D --mode 640 ykksm-decrypt.php $(DESTDIR)$(phpprefix)/ykksm-decrypt.php
+	install -D --mode 640 ykksm-log.php $(DESTDIR)$(phpprefix)/ykksm-log.php
 	install -D --mode 640 ykksm-utils.php $(DESTDIR)$(phpprefix)/ykksm-utils.php
 	install -D ykksm-gen-keys $(DESTDIR)$(binprefix)/ykksm-gen-keys
 	install -D ykksm-import $(DESTDIR)$(binprefix)/ykksm-import

--- a/ykksm-config.php
+++ b/ykksm-config.php
@@ -15,5 +15,6 @@ $db_dsn      = "$dbtype:dbname=$dbname;host=127.0.0.1";
 $db_username = $dbuser;
 $db_password = $dbpass;
 $db_options  = array();
-$logfacility = LOG_AUTH;
+
+$logging     = FALSE; // set to TRUE to log anything
 ?>


### PR DESCRIPTION
Per https://github.com/Yubico/yubikey-val/issues/21 and comments seen at http://coderinaworldofcode.blogspot.com.au/2012/10/yubikey-key-storage-module-review.html, it would be nice if the KSM didn't log lots of debug and plaintext decrypted stuff by default, given the sensitivity of this component.

Additionally the YK-KSM's logging is inconsistent with the YK-VAL's logging functions.

The following change makes the YK-KSM logging methodology consistent with YK-VAL's logger functions. It also introduces a '$logging' boolean for the config, as flag to disable or enable logging entirely.

It defaults to FALSE (off) for security, but can be switched easily.

This change also implies (re?)introduction of /var/log/ykval.log rather than /var/log/auth.log (making https://github.com/Yubico/yubikey-ksm/issues/14 obsolete)

Unsure if there is a better way to handle it all (log only certain 'levels' and not others?), so this pull request is just a suggestion, feel free to use ideas in it.
